### PR TITLE
Added updatecli to update Epinio

### DIFF
--- a/.github/updatecli/updatecli.d/epinio.yaml
+++ b/.github/updatecli/updatecli.d/epinio.yaml
@@ -1,0 +1,47 @@
+---
+title: "Bump CIVO marketplace Epinio version"
+
+# Define git repository configuration to know where to push changes
+scms:
+  kubernetes-marketplace:
+    kind: "github"
+    spec:
+      user: "{{ .github.epinio.user }}"
+      email: "{{ .github.epinio.email }}"
+      username: "{{ .github.epinio.username }}"
+      owner: "epinio"
+      repository: "kubernetes-marketplace"
+      branch: master
+      token: '{{ requiredEnv .github.epinio.token }}'
+
+# Get the latest Epinio Helm Chart version
+sources:
+  epinio-chart:
+    scmid: kubernetes-marketplace
+    kind: helmchart
+    spec:
+      url: https://epinio.github.io/helm-charts
+      name: epinio
+
+targets:
+  # Update the epinio/manifest.yaml
+  update-manifest:
+    name: Update epinio/manifest.yaml
+    scmid: kubernetes-marketplace
+    kind: yaml
+    transformers:
+      - addprefix: v
+    spec:
+      file: epinio/manifest.yaml
+      key: version
+
+  # Update the epinio/install.sh
+  update-install:
+    name: Update epinio/install.sh
+    scmid: kubernetes-marketplace
+    kind: file
+    spec:
+      file: epinio/install.sh
+      matchpattern: '--version (\d.\d.\d)'
+      replacepattern: '--version {{ source "epinio-chart" }}'
+

--- a/.github/updatecli/values.yaml
+++ b/.github/updatecli/values.yaml
@@ -1,0 +1,6 @@
+github:
+  epinio:
+    user: "GitHub Actions"
+    email: "41898282+github-actions[bot]@users.noreply.github.com"
+    username: "UPDATECLI_GITHUB_ACTOR"
+    token: "UPDATECLI_GITHUB_TOKEN"

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,0 +1,38 @@
+---
+name: "Updatecli: Dependency Management"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * *'
+  repository_dispatch:
+    types: [epinio-release]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@v2
+      
+      # sync repo with upstream
+      - name: Sync upstream changes
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
+        with:
+          target_sync_branch: master
+          target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          upstream_sync_branch: master
+          upstream_sync_repo: civo/kubernetes-marketplace
+
+      - name: Updatecli apply
+        run: "updatecli apply --config .github/updatecli/updatecli.d --values .github/updatecli/values.yaml --experimental"
+        env:
+          UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix https://github.com/epinio/epinio/issues/1957

This PR adds the action to run `updatecli` and update the CIVO marketplace.

After a release, or at scheduled intervals, this job will sync the repository with the upstream, the updatecli will check for new helm chart releases and eventually push the changes to a new branch.

This branch will still need a manual step to open the PR to the upstream repository.